### PR TITLE
Set max request body size and timeouts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,6 @@ workflows:
             branches:
               only:
                 - main
-                - zachlipton/max-body-size
 
 jobs:
   unit_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ workflows:
             branches:
               only:
                 - main
+                - zachlipton/max-body-size
 
 jobs:
   unit_test:

--- a/.ebextensions/02_max_body_size.config
+++ b/.ebextensions/02_max_body_size.config
@@ -1,0 +1,11 @@
+files:
+    "/etc/nginx/conf.d/proxy.conf" :
+        mode: "000755"
+        owner: root
+        group: root
+        content: |
+           client_max_body_size 50M;
+
+container_commands:
+  restart:
+    command: service nginx reload

--- a/.ebextensions/02_max_body_size.config
+++ b/.ebextensions/02_max_body_size.config
@@ -1,11 +1,13 @@
 files:
-    "/etc/nginx/conf.d/proxy.conf" :
+    "/etc/nginx/conf.d/proxy.conf":
         mode: "000755"
         owner: root
         group: root
         content: |
            client_max_body_size 50M;
-
-container_commands:
-  restart:
-    command: service nginx reload
+           client_header_timeout   300;
+           client_body_timeout     300;
+           send_timeout            300;
+           proxy_connect_timeout   300;
+           proxy_read_timeout      300;
+           proxy_send_timeout      300;

--- a/.ebextensions/03_elb_timeout.config
+++ b/.ebextensions/03_elb_timeout.config
@@ -1,0 +1,4 @@
+option_settings:
+   - namespace: aws:elbv2:loadbalancer
+     option_name: IdleTimeout
+     value: 300


### PR DESCRIPTION
This works, in the sense that it does what it's supposed to (it's already been tested through trial-and-error on production), but reveals other more intractable problems that will be an issue with the 60 second apps script request limit. So we'll need to work around that (perhaps by having the python write directly to the sheet or something else that's annoying to deal with) unless all our operations magically get a lot faster. But we can think about that tomorrow.