### PR TITLE
Add quality_checks command

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,5 @@ Example:
 flask aggregate_outbreaks "https://docs.google.com/spreadsheets/d/1r7DU4FN_spe71nMa2lsIXAXgGEBw8mwyryiDlby3Q6w/edit#gid=273523772" # outputs to STDOUT
 flask aggregate_outbreaks --outfile IL.csv "https://docs.google.com/spreadsheets/d/1r7DU4FN_spe71nMa2lsIXAXgGEBw8mwyryiDlby3Q6w/edit#gid=273523772" # writes to file
 flask close_outbreaks "https://docs.google.com/spreadsheets/d/1r7DU4FN_spe71nMa2lsIXAXgGEBw8mwyryiDlby3Q6w/edit#gid=273523772"
+flask quality_checks "https://docs.google.com/spreadsheets/d/1r7DU4FN_spe71nMa2lsIXAXgGEBw8mwyryiDlby3Q6w/edit#gid=273523772"
 ```

--- a/flask_server.py
+++ b/flask_server.py
@@ -42,3 +42,10 @@ def cli_aggregate_outbreaks(outfile, url):
 @click.argument("url")
 def cli_close_outbreaks(outfile, url):
     ltc.cli_close_outbreaks_nm_ar(outfile, url)
+
+
+@app.cli.command("quality_checks")
+@click.option('-o', '--outfile')
+@click.argument("url")
+def cli_close_outbreaks(outfile, url):
+    ltc.cli_quality_checks(outfile, url)


### PR DESCRIPTION
Find duplicate rows with open outbreaks and non-numeric data in numeric columns. I'm not 100% sure that I checked the  things we wanted to check, but I think I did?

You can run it like (make sure you're on the right tab when getting the url) `flask quality_checks "https://docs.google.com/spreadsheets/d/1r7DU4FN_spe71nMa2lsIXAXgGEBw8mwyryiDlby3Q6w/edit#gid=273523772"` and you'll get back CSV output—the `--outfile` parameter is optional if you want it saved to a file for you

```
20210128,IL,COOK,,SYMPHONY OF SOUTH SHORE,Uncategorized LTC,Nursing Home,Federal,,145977,,,OPEN,,,,,,,,,,,,,,,,,,,,,,188.0,,29.0,,,,,Multiple open outbreak rows with different data
20210128,IL,COOK,,SYMPHONY OF SOUTH SHORE,Uncategorized LTC,Nursing Home,Federal,,145977,,,OPEN,,,,,,,,,,,,,,,,,,,,,,42.0,,6.0,,,,,Multiple open outbreak rows with different data
20200924,IL,COOK,,NORTH SHORE PLACE,Uncategorized LTC,Uncategorized LTC,State,, ,,,OPEN,,,,,,,abc,,,,,,,,,,,,,,,,,0.0,,,,,Non-numeric value in numeric column Cume_Staff_ProbPos
20200924,IL,COOK,,NORTHBROOK INN MEMORY CARE,Uncategorized LTC,Uncategorized LTC,State,, ,,,OPEN,,,,,,,,a3a,,,,,,,,,,,,,,,,10.0,,,,,Non-numeric value in numeric column Cume_Staff_Death
````
It's easy to efficiently test for non-numeric data in large columns, but there's no way to get the rows containing the non-numeric data without iterating over all of them. But it's still <30s on IL so it should be fast enough.