### PR TITLE
Add gsheets writing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Example:
 ```shell
 flask aggregate_outbreaks "https://docs.google.com/spreadsheets/d/1r7DU4FN_spe71nMa2lsIXAXgGEBw8mwyryiDlby3Q6w/edit#gid=273523772" # outputs to STDOUT
 flask aggregate_outbreaks --outfile IL.csv "https://docs.google.com/spreadsheets/d/1r7DU4FN_spe71nMa2lsIXAXgGEBw8mwyryiDlby3Q6w/edit#gid=273523772" # writes to file
+flask aggregate_outbreaks --write-to-sheet "https://docs.google.com/spreadsheets/d/1r7DU4FN_spe71nMa2lsIXAXgGEBw8mwyryiDlby3Q6w/edit#gid=273523772" # publishes to google sheets
 flask close_outbreaks "https://docs.google.com/spreadsheets/d/1r7DU4FN_spe71nMa2lsIXAXgGEBw8mwyryiDlby3Q6w/edit#gid=273523772"
 flask quality_checks "https://docs.google.com/spreadsheets/d/1r7DU4FN_spe71nMa2lsIXAXgGEBw8mwyryiDlby3Q6w/edit#gid=273523772"
 ```

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Example:
 ```shell
 flask aggregate_outbreaks "https://docs.google.com/spreadsheets/d/1r7DU4FN_spe71nMa2lsIXAXgGEBw8mwyryiDlby3Q6w/edit#gid=273523772" # outputs to STDOUT
 flask aggregate_outbreaks --outfile IL.csv "https://docs.google.com/spreadsheets/d/1r7DU4FN_spe71nMa2lsIXAXgGEBw8mwyryiDlby3Q6w/edit#gid=273523772" # writes to file
-flask aggregate_outbreaks --write-to-sheet "https://docs.google.com/spreadsheets/d/1r7DU4FN_spe71nMa2lsIXAXgGEBw8mwyryiDlby3Q6w/edit#gid=273523772" # publishes to google sheets
+flask aggregate_outbreaks --write-to-sheet "https://docs.google.com/spreadsheets/d/1r7DU4FN_spe71nMa2lsIXAXgGEBw8mwyryiDlby3Q6w/edit#gid=1101937167" "https://docs.google.com/spreadsheets/d/1r7DU4FN_spe71nMa2lsIXAXgGEBw8mwyryiDlby3Q6w/edit#gid=273523772" # publishes to google sheets
 flask close_outbreaks "https://docs.google.com/spreadsheets/d/1r7DU4FN_spe71nMa2lsIXAXgGEBw8mwyryiDlby3Q6w/edit#gid=273523772"
 flask quality_checks "https://docs.google.com/spreadsheets/d/1r7DU4FN_spe71nMa2lsIXAXgGEBw8mwyryiDlby3Q6w/edit#gid=273523772"
 ```

--- a/app/api/aggregate_outbreaks.py
+++ b/app/api/aggregate_outbreaks.py
@@ -166,5 +166,5 @@ def do_aggregate_outbreaks(df):
     return processed_df
 
 
-def cli_aggregate_outbreaks(outfile, url):
-    utils.cli_for_function(do_aggregate_outbreaks, outfile, url)
+def cli_aggregate_outbreaks(outfile, url, write_to_sheet=False):
+    utils.cli_for_function(do_aggregate_outbreaks, outfile, url, write_to_sheet=write_to_sheet)

--- a/app/api/gsheets.py
+++ b/app/api/gsheets.py
@@ -3,6 +3,9 @@ import re
 import gspread
 import datetime
 
+from gspread import Worksheet, WorksheetNotFound
+from gspread.utils import finditem
+
 
 def csv_url_for_sheets_url(url):
     """extract the parameters from a google docs url and formulate a CSV export url"""
@@ -16,24 +19,48 @@ def csv_url_for_sheets_url(url):
         raise click.Abort()
 
 
+def gid_for_sheets_url(url):
+    """extract just the gid (worksheet id) from a google docs url"""
+    m = re.search('.*#gid=(\\d+)$', url)
+    if m:
+        return m.group(1)
+    else:
+        click.echo('Invalid Google Sheets URL')
+        raise click.Abort()
+
+
 def save_to_sheet(target_sheet_url, df):
-    """save df to the google doc at target_sheet_url. The data will always be saved to the first
-    tab within the sheet, and the old contents of the tab will be saved to a backup tab before being replaced.
+    """save df to the google doc at target_sheet_url. The data will always be saved to the specified
+    tab within the sheet (specified within the url), and the old contents of the tab will be saved to a backup
+    tab before being replaced.
 
     Requires authentication. You must have the client secret installed in `~/.config/gspread/credentials.json`.
     This function will open a web browser on first run to authenticate the user."""
     gc = gspread.oauth()
     sh = gc.open_by_url(target_sheet_url)
-    ws = sh.get_worksheet(0)  # always get the first tab
+
+    # we need to find the target worksheet/tab. gspread doesn't provide a way to lookup tabs by id (just index or name)
+    # so we'll repurpose its usual logic to do it ourselves
+    target_gid = gid_for_sheets_url(target_sheet_url)
+    sheet_data = sh.fetch_sheet_metadata()
+    try:
+        item = finditem(
+            lambda x: str(x['properties']['sheetId']) == target_gid,
+            sheet_data['sheets'],
+        )
+        ws = Worksheet(sh, item['properties'])
+    except (StopIteration, KeyError):
+        raise WorksheetNotFound(target_gid)
+
     ws_name = ws.title
 
-    # make a backup of the target sheet and then clear its contents
+    # make a backup of the target worksheet and then clear its contents
     ws.duplicate(2, new_sheet_name=f"{ws_name}_backup_{datetime.datetime.today().strftime('%Y%m%d%H%M%S')}")
     ws.clear()
 
-    # turn the data into a 2D array and add the column headers
-    data = df.fillna('').values.tolist()
-    data.insert(0, df.columns.to_list())
+    # turn the data into a 2D array with column headers
+    data = [df.columns.to_list()]
+    data.extend(df.fillna('').values.tolist())
 
     # post it to the sheet
     ws.update('A:ZZ', data)

--- a/app/api/gsheets.py
+++ b/app/api/gsheets.py
@@ -1,0 +1,39 @@
+import click
+import re
+import gspread
+import datetime
+
+
+def csv_url_for_sheets_url(url):
+    """extract the parameters from a google docs url and formulate a CSV export url"""
+    m = re.search('.*\/d\/(.*)\/edit.*#gid=(.*)', url)
+    if m:
+        key = m.group(1)
+        gid = m.group(2)
+        return f"https://docs.google.com/spreadsheets/d/{key}/export?format=csv&gid={gid}"
+    else:
+        click.echo('Invalid Google Sheets URL')
+        raise click.Abort()
+
+
+def save_to_sheet(target_sheet_url, df):
+    """save df to the google doc at target_sheet_url. The data will always be saved to the first
+    tab within the sheet, and the old contents of the tab will be saved to a backup tab before being replaced.
+
+    Requires authentication. You must have the client secret installed in `~/.config/gspread/credentials.json`.
+    This function will open a web browser on first run to authenticate the user."""
+    gc = gspread.oauth()
+    sh = gc.open_by_url(target_sheet_url)
+    ws = sh.get_worksheet(0)  # always get the first tab
+    ws_name = ws.title
+
+    # make a backup of the target sheet and then clear its contents
+    ws.duplicate(2, new_sheet_name=f"{ws_name}_backup_{datetime.datetime.today().strftime('%Y%m%d%H%M%S')}")
+    ws.clear()
+
+    # turn the data into a 2D array and add the column headers
+    data = df.fillna('').values.tolist()
+    data.insert(0, df.columns.to_list())
+
+    # post it to the sheet
+    ws.update('A:ZZ', data)

--- a/app/api/utils.py
+++ b/app/api/utils.py
@@ -43,7 +43,7 @@ def cli_for_function(function, outfile, url, write_to_sheet=False):
     processed_df = function(df)
 
     if write_to_sheet:
-        save_to_sheet(orig_url, processed_df)
+        save_to_sheet(write_to_sheet, processed_df)
 
     if outfile:
         processed_df.to_csv(outfile, index=False)

--- a/flask_server.py
+++ b/flask_server.py
@@ -32,14 +32,17 @@ def deploy():
 
 @app.cli.command("aggregate_outbreaks")
 @click.option('-o', '--outfile')
+@click.option('--write-to-sheet', is_flag=True)
 @click.argument("url")
-def cli_aggregate_outbreaks(outfile, url):
-    aggregate_outbreaks.cli_aggregate_outbreaks(outfile, url)
+def cli_aggregate_outbreaks(outfile, url, write_to_sheet):
+    aggregate_outbreaks.cli_aggregate_outbreaks(outfile, url, write_to_sheet=write_to_sheet)
+
 
 @app.cli.command("close_outbreaks")
 @click.option('-o', '--outputdir')
 def cli_close_outbreaks(outputdir):
     close_outbreaks.cli_close_outbreaks_nm_ar(outputdir)
+
 
 @app.cli.command("quality_checks")
 @click.option('-o', '--outfile')

--- a/flask_server.py
+++ b/flask_server.py
@@ -32,7 +32,7 @@ def deploy():
 
 @app.cli.command("aggregate_outbreaks")
 @click.option('-o', '--outfile')
-@click.option('--write-to-sheet', is_flag=True)
+@click.option('--write-to-sheet')
 @click.argument("url")
 def cli_aggregate_outbreaks(outfile, url, write_to_sheet):
     aggregate_outbreaks.cli_aggregate_outbreaks(outfile, url, write_to_sheet=write_to_sheet)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ flask-restful
 python-decouple
 pandas
 click~=7.1.2
+gspread


### PR DESCRIPTION
This is tested and appears to work as expected, but requires a little more testing before I'd truly trust it. I only added it to aggregate_outbreaks for the moment, since potentially reorganizing the CLI seems like a separate project. 

Invoke it like `flask aggregate_outbreaks --write-to-sheet "https://docs.google.com/spreadsheets/d/140beN_yIbiG_hy3EwfKpu02MCReRi-kiupcYOcazKCc/edit#gid=881981274"`. It will read from the specified sheet URL (including the selected tab in the `gid`), do its processing, and then write back out to the sheet. When it writes to the sheet, it always replaces the sheet's first tab, and it makes a backup copy of the tab within the sheet first (one of the reasons I don't trust it yet is because I'm not sure how that will work out for FL). 

This requires a small credentials file to be placed in `~/.config/gspread/credentials.json`, which I'll provide out of band. 

If you don't pass `--write-to-sheet`, it runs as usual.