### PR TITLE
Adding a WIP "process" module that runs a bunch of transformations on dataframes and saves the result in the specified way(s).

### DIFF
--- a/app/api/process.py
+++ b/app/api/process.py
@@ -34,6 +34,7 @@ _FUNCTION_LISTS = {
 
 
 def get_all_state_urls():
+    # TODO: move this out into something like config.py so it's not buried here
     url_link = 'https://docs.google.com/spreadsheets/d/1kBL149bp8PWd_NMFm8Gxj-jXToSNEU9YNgQs0o9tREs/gviz/tq?tqx=out:csv&sheet=State_links'
     url_df = pd.read_csv(url_link)
     return url_df
@@ -47,7 +48,7 @@ def get_final_url(state, url_df):
     return url_df.loc[url_df.State == state].iloc[0].Final
 
 
-def cli_process_state(state, write_to_final=False, other_sheet_url=None, local_path=None):
+def cli_process_state(state, overwrite_final_gsheet=False, out_sheet_url=None, outfile=None):
     # get the source sheet
     url_df = get_all_state_urls()
     entry_url = get_entry_url(state, url_df)
@@ -67,20 +68,20 @@ def cli_process_state(state, write_to_final=False, other_sheet_url=None, local_p
         flask.current_app.logger.info('Running %s took %.1f seconds, %d to %d rows' % (
             func.__name__, (t2 - t1), orig_num_rows, resulting_num_rows))
 
-    if write_to_final:
+    if overwrite_final_gsheet:
         flask.current_app.logger.info('Writing to final sheet!!')
         final_url = get_final_url(state, url_df)
         utils.save_to_sheet(final_url, df)
         flask.current_app.logger.info('Done.')
 
-    if other_sheet_url:
-        flask.current_app.logger.info('Writing to other sheet: %s' % other_sheet_url)
-        utils.save_to_sheet(other_sheet_url, df)
+    if out_sheet_url:
+        flask.current_app.logger.info('Writing to other sheet: %s' % out_sheet_url)
+        utils.save_to_sheet(out_sheet_url, df)
         flask.current_app.logger.info('Done.')
 
-    if local_path:
-        flask.current_app.logger.info('Writing to local path: %s' % local_path)
-        df.to_csv(local_path, index=False)
+    if outfile:
+        flask.current_app.logger.info('Writing to local path: %s' % outfile)
+        df.to_csv(outfile, index=False)
         flask.current_app.logger.info('Done.')
 
 

--- a/app/api/process.py
+++ b/app/api/process.py
@@ -1,0 +1,95 @@
+"""
+The main "processing" module.
+"""
+
+import flask
+import numpy as np
+import pandas as pd
+from time import time
+
+from app.api import utils, ltc, aggregate_outbreaks, close_outbreaks, data_quality_checks, \
+    check_cumulative, unreset_cumulative
+
+
+_FUNCTION_LISTS = {
+    'CO': [utils.standardize_data, aggregate_outbreaks.collapse_outbreak_rows],
+    'DE': [utils.standardize_data, aggregate_outbreaks.collapse_outbreak_rows],
+    'FL': [
+        utils.standardize_data,
+        aggregate_outbreaks.preclean_FL,
+        aggregate_outbreaks.collapse_outbreak_rows,
+        aggregate_outbreaks.postclean_FL,
+        ],
+    'IL': [utils.standardize_data, aggregate_outbreaks.collapse_outbreak_rows],
+    'ME': [utils.standardize_data, aggregate_outbreaks.collapse_outbreak_rows],
+    'MN': [utils.standardize_data, aggregate_outbreaks.collapse_outbreak_rows],
+    'ND': [
+        utils.standardize_data,
+        lambda df: aggregate_outbreaks.collapse_outbreak_rows(df, add_outbreak_and_cume=False),
+        ],  ## CHECK THIS
+    'NJ': [utils.standardize_data, aggregate_outbreaks.collapse_outbreak_rows],
+    'OR': [utils.standardize_data, aggregate_outbreaks.collapse_outbreak_rows],
+    'WY': [utils.standardize_data, aggregate_outbreaks.collapse_outbreak_rows],
+}
+
+
+def get_all_state_urls():
+    url_link = 'https://docs.google.com/spreadsheets/d/1kBL149bp8PWd_NMFm8Gxj-jXToSNEU9YNgQs0o9tREs/gviz/tq?tqx=out:csv&sheet=State_links'
+    url_df = pd.read_csv(url_link)
+    return url_df
+
+
+def get_entry_url(state, url_df):
+    return url_df.loc[url_df.State == state].iloc[0].Entry
+
+
+def get_final_url(state, url_df):
+    return url_df.loc[url_df.State == state].iloc[0].Final
+
+
+def cli_process_state(state, write_to_final=False, other_sheet_url=None, local_path=None):
+    # get the source sheet
+    url_df = get_all_state_urls()
+    entry_url = get_entry_url(state, url_df)
+    flask.current_app.logger.info('Reading entry sheet from: %s' % entry_url)
+
+    csv_url = utils.csv_url_for_sheets_url(entry_url)
+    df = pd.read_csv(csv_url)
+
+    # apply transformation functions in order
+    functions = _FUNCTION_LISTS[state]
+    for func in functions:
+        t1 = time()
+        orig_num_rows = df.shape[0]
+        df = func(df)
+        resulting_num_rows = df.shape[0]
+        t2 = time()
+        flask.current_app.logger.info('Running %s took %.1f seconds, %d to %d rows' % (
+            func.__name__, (t2 - t1), orig_num_rows, resulting_num_rows))
+
+    if write_to_final:
+        flask.current_app.logger.info('Writing to final sheet!!')
+        final_url = get_final_url(state, url_df)
+        utils.save_to_sheet(final_url, df)
+        flask.current_app.logger.info('Done.')
+
+    if other_sheet_url:
+        flask.current_app.logger.info('Writing to other sheet: %s' % other_sheet_url)
+        utils.save_to_sheet(other_sheet_url, df)
+        flask.current_app.logger.info('Done.')
+
+    if local_path:
+        flask.current_app.logger.info('Writing to local path: %s' % local_path)
+        df.to_csv(local_path, index=False)
+        flask.current_app.logger.info('Done.')
+
+
+def main(args_list=None):
+    if args_list is None:
+        args_list = sys.argv[1:]
+    args = parser.parse_args(args_list)
+    cli_process_state(args.state, args.write_to_final, args.write_to_other_sheet, args.local_path)
+
+
+if __name__ == '__main__':
+    main()

--- a/app/api/process.py
+++ b/app/api/process.py
@@ -12,6 +12,7 @@ from app.api import utils, ltc, aggregate_outbreaks, close_outbreaks, data_quali
 
 
 _FUNCTION_LISTS = {
+    'CA': [utils.standardize_data],
     'CO': [utils.standardize_data, aggregate_outbreaks.collapse_outbreak_rows],
     'DE': [utils.standardize_data, aggregate_outbreaks.collapse_outbreak_rows],
     'FL': [

--- a/app/api/utils.py
+++ b/app/api/utils.py
@@ -26,6 +26,7 @@ def standardize_data(df):
     # drop any rows with empty dates
     df.drop(df[pd.isnull(df['Date'])].index, inplace = True)
     df['Date'] = df['Date'].astype(int)
+    return df
 
 
 def cli_for_function(function, outfile, url, write_to_sheet=False):
@@ -34,7 +35,6 @@ def cli_for_function(function, outfile, url, write_to_sheet=False):
     Function is any function that takes in a pandas dataframe and returns a transformed dataframe"""
 
     # URL can be a local CSV or a link
-    orig_url = url
     if not url.endswith('.csv'):
         url = csv_url_for_sheets_url(url)
     df = pd.read_csv(url)

--- a/flask_server.py
+++ b/flask_server.py
@@ -4,7 +4,8 @@ import click
 
 from app import create_app
 from decouple import config
-from app.api import ltc, aggregate_outbreaks, close_outbreaks, data_quality_checks, check_cumulative, unreset_cumulative
+from app.api import ltc, aggregate_outbreaks, close_outbreaks, data_quality_checks, \
+    check_cumulative, unreset_cumulative, process as process_module
 
 import config as configs
 
@@ -28,19 +29,6 @@ if env_config == 'production':
 def deploy():
     """Run deployment tasks."""
     return  # we have no deployment tasks
-
-
-@app.cli.command("aggregate_outbreaks")
-@click.option('-o', '--outfile')
-@click.option('--write-to-sheet')
-@click.argument("url")
-def cli_aggregate_outbreaks(outfile, url, write_to_sheet):
-    aggregate_outbreaks.cli_aggregate_outbreaks(outfile, url, write_to_sheet=write_to_sheet)
-
-
-@app.cli.command("aggregate_outbreaks_all")
-def cli_aggregate_outbreaks_all():
-    aggregate_outbreaks.cli_aggregate_outbreaks_all()
 
 
 @app.cli.command("close_outbreaks")
@@ -85,3 +73,14 @@ def cli_check_data_types_all():
 @click.option('-w', '--onlythisweek', is_flag=True)
 def check_cumulative_data(outfile, onlythisweek):
     check_cumulative.cli_check_cumulative_data(outfile, onlythisweek)
+
+
+@app.cli.command("process")
+@click.option('--state', default='', help='State abbreviation to run for, e.g. "CA"')
+@click.option('--write-to-final', is_flag=True)
+@click.option('--other-sheet-url', default='', help='Other sheet URL to write processed file to; '
+    'use if writing to something other than final sheet')
+@click.option('--local-path', default='', help='Local CSV path to write processed file to')
+def process(state, write_to_final, other_sheet_url, local_path):
+    process_module.cli_process_state(state, write_to_final=write_to_final,
+        other_sheet_url=other_sheet_url, local_path=local_path)

--- a/flask_server.py
+++ b/flask_server.py
@@ -77,10 +77,18 @@ def check_cumulative_data(outfile, onlythisweek):
 
 @app.cli.command("process")
 @click.option('--state', default='', help='State abbreviation to run for, e.g. "CA"')
-@click.option('--write-to-final', is_flag=True)
-@click.option('--other-sheet-url', default='', help='Other sheet URL to write processed file to; '
-    'use if writing to something other than final sheet')
-@click.option('--local-path', default='', help='Local CSV path to write processed file to')
-def process(state, write_to_final, other_sheet_url, local_path):
-    process_module.cli_process_state(state, write_to_final=write_to_final,
-        other_sheet_url=other_sheet_url, local_path=local_path)
+@click.option('--overwrite-final-gsheet', is_flag=True)
+@click.option('--out-sheet-url', default='',
+    help='Write the processed data to the specified Google Sheet url')
+@click.option('--outfile', default='',
+    help='Write the processed data to CSV file at this local path')
+def process(state, overwrite_final_gsheet, out_sheet_url, outfile):
+    """Process all data from STATE as defined in the Sheet of Sheets.
+
+    The processing functions applied to each state are defined in app/api/process.py. 
+    The resulting output can be saved to the final sheet defined in the Sheet of Sheets
+    (--write-to-gsheets), to a specified sheet url (--out-sheet-url), or to a local CSV file 
+    (--outfile).
+    """
+    process_module.cli_process_state(state, overwrite_final_gsheet=overwrite_final_gsheet,
+        out_sheet_url=out_sheet_url, outfile=outfile)


### PR DESCRIPTION
For this example I'm moving the aggregate-outbreaks logic execution into the process module, and removing a couple of the flask server CLI functions/utilities associated with it.

The process module makes a dictionary of states to a list of functions, run in sequence. The input is always in the "entry" column specified in the "sheet of sheets" URLs spreadsheet, so that we can centralize around that as the set of URLs we use. The output is written to the "final" sheet specified in the URLs spreadsheet, written locally, and/or written to some other URL specified by the user.