### PR TITLE
Add NM/AR close-outbreaks functions to the process module.

### DIFF
--- a/app/api/close_outbreaks.py
+++ b/app/api/close_outbreaks.py
@@ -82,23 +82,3 @@ def close_outbreaks(df):
     filled_in_state = filled_in_state.convert_dtypes()
     filled_in_state.reset_index(drop=True, inplace=True)
     return filled_in_state
-
-
-def do_close_outbreaks_nm_ar(df):
-    flask.current_app.logger.info('DataFrame loaded: %d rows' % df.shape[0])
-
-    state = set(df['State']).pop()
-    utils.standardize_data(df)
-
-    t1 = time()
-    processed_df = close_outbreaks(df)
-    t2 = time()
-
-    # this will go into the lambda logs
-    flask.current_app.logger.info('Closing outbreaks for %s took %.1f seconds, %d to %d rows' % (
-        state, (t2 - t1), df.shape[0], processed_df.shape[0]))
-
-    return processed_df
-
-def cli_close_outbreaks_nm_ar(outputDir):
-    utils.run_function_on_states(do_close_outbreaks_nm_ar, ["NM", "AR"], [], outputDir)

--- a/app/api/ltc.py
+++ b/app/api/ltc.py
@@ -41,12 +41,3 @@ def api_aggregate_outbreaks():
     processed_df = aggregate_outbreaks.do_aggregate_outbreaks(df)
 
     return Response(processed_df.to_csv(index=False), mimetype='text/csv')
-
-
-@api.route('/close-outbreaks-nm-ar', methods=['POST'])
-def api_close_outbreaks_nm_ar():
-    payload = flask.request.data.decode('utf-8')
-    df = pd.read_csv(io.StringIO(payload))
-    processed_df = close_outbreaks.do_close_outbreaks_nm_ar(df)
-
-    return Response(processed_df.to_csv(index=False), mimetype='text/csv')

--- a/app/api/process.py
+++ b/app/api/process.py
@@ -12,6 +12,7 @@ from app.api import utils, ltc, aggregate_outbreaks, close_outbreaks, data_quali
 
 
 _FUNCTION_LISTS = {
+    'AR': [utils.standardize_data, close_outbreaks.close_outbreaks],
     'CA': [utils.standardize_data],
     'CO': [utils.standardize_data, aggregate_outbreaks.collapse_outbreak_rows],
     'DE': [utils.standardize_data, aggregate_outbreaks.collapse_outbreak_rows],
@@ -29,6 +30,7 @@ _FUNCTION_LISTS = {
         lambda df: aggregate_outbreaks.collapse_outbreak_rows(df, add_outbreak_and_cume=False),
         ],  ## CHECK THIS
     'NJ': [utils.standardize_data, aggregate_outbreaks.collapse_outbreak_rows],
+    'NM': [utils.standardize_data, close_outbreaks.close_outbreaks],
     'OR': [utils.standardize_data, aggregate_outbreaks.collapse_outbreak_rows],
     'WY': [utils.standardize_data, aggregate_outbreaks.collapse_outbreak_rows],
 }

--- a/flask_server.py
+++ b/flask_server.py
@@ -31,12 +31,6 @@ def deploy():
     return  # we have no deployment tasks
 
 
-@app.cli.command("close_outbreaks")
-@click.option('-o', '--outputdir')
-def cli_close_outbreaks(outputdir):
-    close_outbreaks.cli_close_outbreaks_nm_ar(outputdir)
-
-
 @app.cli.command("update_2021_ky")
 @click.option('-o', '--outfile')
 @click.option('--write-to-sheet')


### PR DESCRIPTION
cc @joshzarrabi - this will run NM/AR close outbreaks scripts on "entry" data, so that we keep the organization of reading in entry and writing to final (as opposed to doing any data modifications using "final" as the input)