### PR TITLE
A couple more state functions:

### DIFF
--- a/app/api/close_outbreaks.py
+++ b/app/api/close_outbreaks.py
@@ -53,7 +53,18 @@ def add_info(record, last_collected, all_data, current_date):
 
 def clear_outbreak_status(df):
     # for some states like IA, we need to remove outbreak statuses from the final product
+
+    # TODO: put this funcitonality into add_info instead of clearing after the fact
     df['Outbrk_Status'] = ''
+    return df
+
+
+def clear_closed_outbreak_status(df):
+    # for states like KS, even as we close an outbreak we can't mark it "closed" so just leaving
+    # all "closed" rows blank.
+
+    # TODO: put this funcitonality into add_info instead of clearing after the fact
+    df['Outbrk_Status'] = df.Outbrk_Status.apply(lambda x: '' if x == 'Closed' else x)
     return df
 
 

--- a/app/api/process.py
+++ b/app/api/process.py
@@ -15,7 +15,10 @@ from app.api import utils, ltc, aggregate_outbreaks, close_outbreaks, data_quali
 
 _FUNCTION_LISTS = {
     'AR': [utils.standardize_data, close_outbreaks.close_outbreaks],
-    'CA': [utils.standardize_data],
+    'CA': [
+        utils.standardize_data,
+        aggregate_outbreaks.collapse_facility_rows_no_adding,
+        ],
     'CO': [utils.standardize_data, aggregate_outbreaks.collapse_outbreak_rows],
     'DE': [utils.standardize_data, aggregate_outbreaks.collapse_outbreak_rows],
     'FL': [
@@ -30,6 +33,11 @@ _FUNCTION_LISTS = {
         close_outbreaks.close_outbreaks,
         close_outbreaks.clear_outbreak_status],
     'IL': [utils.standardize_data, aggregate_outbreaks.collapse_outbreak_rows],
+    'KS': [
+        utils.standardize_data,
+        close_outbreaks.close_outbreaks,
+        close_outbreaks.clear_closed_outbreak_status,
+        ],
     'KY': [
         utils.standardize_data,
         unreset_cumulative.preclean_KY,
@@ -74,6 +82,7 @@ def cli_process_state(states, overwrite_final_gsheet=False, out_sheet_url=None, 
         flask.current_app.logger.info('Reading entry sheet from: %s' % entry_url)
 
         csv_url = utils.csv_url_for_sheets_url(entry_url)
+        flask.current_app.logger.info('Reading DF from URL: %s' % csv_url)
         df = pd.read_csv(csv_url)
 
         # apply transformation functions in order


### PR DESCRIPTION
- CA: combining "open" and "closed" rows for RCFE and residential care facilities, no adding numbers, just moving the cumulative counts into the open row
- KS: closing outbreak script, but don't mark them "closed" just leave status blank