### PR TITLE
Changing MN function to merge open/closed rows without adding any counts

### DIFF
--- a/app/api/aggregate_outbreaks.py
+++ b/app/api/aggregate_outbreaks.py
@@ -197,10 +197,17 @@ def combine_open_closed_info_do_not_add(df_group, col_map, restrict_facility_typ
     return open_row_df
 
 
-def collapse_facility_rows_no_adding(df, restrict_facility_types=False):
+def collapse_facility_rows_no_adding(df,
+        restrict_facility_types=False,
+        use_facility_type_to_group=True):
     col_map = utils.make_matching_column_name_map(df)
-    processed_df = df.groupby(
-        ['Date', 'Facility', 'County', 'State_Facility_Type'], as_index=False).apply(
+
+    if use_facility_type_to_group:
+        group_cols = ['Date', 'Facility', 'County', 'State_Facility_Type']
+    else:
+        group_cols = ['Date', 'Facility', 'County']
+
+    processed_df = df.groupby(group_cols, as_index=False).apply(
         lambda x: combine_open_closed_info_do_not_add(
             x, col_map, restrict_facility_types=restrict_facility_types))
     processed_df.sort_values(

--- a/app/api/process.py
+++ b/app/api/process.py
@@ -30,19 +30,10 @@ _FUNCTION_LISTS = {
         aggregate_outbreaks.postclean_FL,
         ],
     'GA': [utils.standardize_data],
-    'HI': [
-        utils.standardize_data,
-        close_outbreaks.close_outbreaks,
-        ],
-    'IA': [
-        utils.standardize_data,
-        close_outbreaks.close_outbreaks,
-        ],
+    'HI': [utils.standardize_data, close_outbreaks.close_outbreaks],
+    'IA': [utils.standardize_data, close_outbreaks.close_outbreaks],
     'IL': [utils.standardize_data, aggregate_outbreaks.collapse_outbreak_rows],
-    'KS': [
-        utils.standardize_data,
-        close_outbreaks.close_outbreaks,
-        ],
+    'KS': [utils.standardize_data, close_outbreaks.close_outbreaks],
     'KY': [
         utils.standardize_data,
         unreset_cumulative.preclean_KY,
@@ -50,7 +41,10 @@ _FUNCTION_LISTS = {
         ],
     'ME': [utils.standardize_data, aggregate_outbreaks.collapse_outbreak_rows],
     'MI': [utils.standardize_data],
-    'MN': [utils.standardize_data, aggregate_outbreaks.collapse_outbreak_rows],
+    'MN': [
+        utils.standardize_data,
+        lambda df: aggregate_outbreaks.collapse_facility_rows_no_adding(
+            df, use_facility_type_to_group=False)],
     'NC': [utils.standardize_data, close_outbreaks.close_outbreaks],
     'ND': [
         utils.standardize_data,
@@ -65,10 +59,7 @@ _FUNCTION_LISTS = {
     'TX': [utils.standardize_data, fill_missing_dates.fill_missing_dates],
     'UT': [utils.standardize_data, close_outbreaks.close_outbreaks],
     'VA': [utils.standardize_data, aggregate_outbreaks.collapse_outbreak_rows],
-    'VT': [
-        utils.standardize_data,
-        close_outbreaks.close_outbreaks,
-        ],
+    'VT': [utils.standardize_data, close_outbreaks.close_outbreaks],
     'WI': [utils.standardize_data, close_outbreaks.close_outbreaks],
     'WY': [utils.standardize_data, aggregate_outbreaks.collapse_outbreak_rows],
 }

--- a/app/api/utils.py
+++ b/app/api/utils.py
@@ -41,6 +41,9 @@ def standardize_data(df):
     # drop any rows with empty dates
     df.drop(df[pd.isnull(df['Date'])].index, inplace = True)
     df['Date'] = df['Date'].astype(int)
+
+    # drop full duplicates
+    df.drop_duplicates(inplace=True)
     return df
 
 


### PR DESCRIPTION
Also, using facility and county to group, not facility type.

As part of this, also adding a small row that drops full duplicates as part of data standardization.